### PR TITLE
Add opam build field

### DIFF
--- a/dream-serve.opam
+++ b/dream-serve.opam
@@ -8,3 +8,7 @@ depends: [
   "lwt" {>= "5.4.0"}
   "lwt_ppx"
 ]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]


### PR DESCRIPTION
This allows users to `opam pin` `dream-serve` and use the CLI directly, without having to clone and build the repo.